### PR TITLE
Change WP CLI batch size flag to match AS core

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ Action Scheduler uses WordPress posts to store scheduled actions in the existing
 To migrate actions in bulk using WP-CLI, run the following command:
 
 ```
-wp action-scheduler custom-tables migrate [--batch=<batch>] [--dry-run]
+wp action-scheduler custom-tables migrate [--batch-size=<batch>] [--dry-run]
 ```
 

--- a/src/WP_CLI/Migration_Command.php
+++ b/src/WP_CLI/Migration_Command.php
@@ -33,7 +33,7 @@ class Migration_Command extends WP_CLI_Command {
 			'synopsis'  => [
 				[
 					'type'        => 'assoc',
-					'name'        => 'batch',
+					'name'        => 'batch-size',
 					'optional'    => true,
 					'default'     => 100,
 					'description' => 'The number of actions to process in each batch',
@@ -64,7 +64,7 @@ class Migration_Command extends WP_CLI_Command {
 		$config = $this->get_migration_config( $assoc_args );
 
 		$runner     = new Migration_Runner( $config );
-		$batch_size = isset( $assoc_args[ 'batch' ] ) ? (int) $assoc_args[ 'batch' ] : 100;
+		$batch_size = isset( $assoc_args[ 'batch-size' ] ) ? (int) $assoc_args[ 'batch-size' ] : 100;
 
 		do {
 			$actions_processed     = $runner->run( $batch_size );


### PR DESCRIPTION
Action Scheduler 1.6 is introducing a new WP CLI command which includes a `--batch-size` flag. That serves the same purpose as the `action-scheduler migrate` command being provided by this plugin, but it was using a different name: `--batch`.

This updates the flag to make them consistent with each other.

For more details on the AS core WP CLI command, see Prospress/action-scheduler#89