### PR TITLE
Modify composer.json to avoid conflict with the base AS package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-  "name": "prospress/action-scheduler",
+  "name": "prospress/action-scheduler-custom-tables",
   "version": "1.0.0",
-  "description": "Action Scheduler for WordPress and WooCommerce",
+  "description": "Action Scheduler Custom Tables for WordPress and WooCommerce",
   "type": "wordpress-plugin",
   "license": "GPL-3.0",
   "minimum-stability": "dev",


### PR DESCRIPTION
Prospress/action-scheduler has the same info in its composer.json file. The two shouldn't be the same as it makes it difficult to install this plugin via composer.

There is no issue for this