### PR TITLE
Make get_date_gmt() protected

### DIFF
--- a/src/DB_Store.php
+++ b/src/DB_Store.php
@@ -352,7 +352,7 @@ class DB_Store extends ActionScheduler_Store {
 	 * @throws \InvalidArgumentException
 	 * @return \DateTime The GMT date the action is scheduled to run, or the date that it ran.
 	 */
-	public function get_date_gmt( $action_id ) {
+	protected function get_date_gmt( $action_id ) {
 		/** @var \wpdb $wpdb */
 		global $wpdb;
 		$record = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->actionscheduler_actions} WHERE action_id=%d", $action_id ) );


### PR DESCRIPTION
It's not used publicly, and while it is public in `ActionScheduler_wpPostStore`, it's not defined in `ActionScheduler_Store`, so doesn't need to be public in this new class, and keeping methods protected makes it easier to maintain backward compatibility in future.