### PR TITLE
Save last attempt date for completed actions when migrating to custom tables

### DIFF
--- a/src/DB_Store.php
+++ b/src/DB_Store.php
@@ -21,15 +21,15 @@ class DB_Store extends ActionScheduler_Store {
 	}
 
 
-	public function save_action( ActionScheduler_Action $action, \DateTime $date = null ) {
+	public function save_action( ActionScheduler_Action $action, \DateTime $scheduled_date = null ){
 		try {
 			/** @var \wpdb $wpdb */
 			global $wpdb;
 			$data = [
 				'hook'                 => $action->get_hook(),
 				'status'               => ( $action->is_finished() ? self::STATUS_COMPLETE : self::STATUS_PENDING ),
-				'scheduled_date_gmt'   => $this->get_timestamp( $action, $date ),
-				'scheduled_date_local' => $this->get_local_timestamp( $action, $date ),
+				'scheduled_date_gmt'   => $this->get_timestamp( $action, $scheduled_date ),
+				'scheduled_date_local' => $this->get_local_timestamp( $action, $scheduled_date ),
 				'args'                 => json_encode( $action->get_args() ),
 				'schedule'             => serialize( $action->get_schedule() ),
 				'group_id'             => $this->get_group_id( $action->get_group() ),

--- a/src/DB_Store.php
+++ b/src/DB_Store.php
@@ -21,7 +21,7 @@ class DB_Store extends ActionScheduler_Store {
 	}
 
 
-	public function save_action( ActionScheduler_Action $action, \DateTime $scheduled_date = null ){
+	public function save_action( ActionScheduler_Action $action, \DateTime $scheduled_date = null, \DateTime $last_attempt_date = null ){
 		try {
 			/** @var \wpdb $wpdb */
 			global $wpdb;
@@ -34,6 +34,12 @@ class DB_Store extends ActionScheduler_Store {
 				'schedule'             => serialize( $action->get_schedule() ),
 				'group_id'             => $this->get_group_id( $action->get_group() ),
 			];
+
+			if ( ! is_null( $last_attempt_date ) ) {
+				$data['last_attempt_gmt']   = $this->get_timestamp( $action, $last_attempt_date );
+				$data['last_attempt_local'] = $this->get_local_timestamp( $action, $last_attempt_date );
+			}
+
 			$wpdb->insert( $wpdb->actionscheduler_actions, $data );
 			$action_id = $wpdb->insert_id;
 

--- a/src/Hybrid_Store.php
+++ b/src/Hybrid_Store.php
@@ -174,8 +174,8 @@ class Hybrid_Store extends Store {
 		$this->migration_runner->migrate_actions( $action_ids );
 	}
 
-	public function save_action( ActionScheduler_Action $action, DateTime $date = null ) {
-		return $this->primary_store->save_action( $action, $date );
+	public function save_action( ActionScheduler_Action $action, \DateTime $scheduled_date = null ){
+		return $this->primary_store->save_action( $action, $scheduled_date );
 	}
 
 	public function fetch_action( $action_id ) {

--- a/src/Hybrid_Store.php
+++ b/src/Hybrid_Store.php
@@ -174,8 +174,8 @@ class Hybrid_Store extends Store {
 		$this->migration_runner->migrate_actions( $action_ids );
 	}
 
-	public function save_action( ActionScheduler_Action $action, \DateTime $scheduled_date = null ){
-		return $this->primary_store->save_action( $action, $scheduled_date );
+	public function save_action( ActionScheduler_Action $action, \DateTime $scheduled_date = null, \DateTime $last_attempt_date = null ){
+		return $this->primary_store->save_action( $action, $scheduled_date, $last_attempt_date );
 	}
 
 	public function fetch_action( $action_id ) {

--- a/src/Migration/Action_Migrator.php
+++ b/src/Migration/Action_Migrator.php
@@ -37,7 +37,11 @@ class Action_Migrator {
 		}
 
 		try {
-			$destination_action_id = $this->destination->save_action( $action );
+
+			// Make sure the last attempt date is set correctly for completed and failed actions
+			$last_attempt_date = ( $status !== \ActionScheduler_Store::STATUS_PENDING ) ? $this->source->get_date( $source_action_id ) : null;
+
+			$destination_action_id = $this->destination->save_action( $action, null, $last_attempt_date );
 		} catch ( \Exception $e ) {
 			do_action( 'action_scheduler/custom_tables/migrate_action_failed', $source_action_id, $this->source, $this->destination );
 

--- a/tests/phpunit/jobstore/DB_Store_Test.php
+++ b/tests/phpunit/jobstore/DB_Store_Test.php
@@ -23,6 +23,24 @@ class DB_Store_Test extends UnitTestCase {
 		$this->assertNotEmpty( $action_id );
 	}
 
+	public function test_create_action_with_last_attempt_date() {
+		$scheduled_date    = as_get_datetime_object( strtotime( '-24 hours' ) );
+		$last_attempt_date = as_get_datetime_object( strtotime( '-23 hours' ) );
+
+		$action = new ActionScheduler_FinishedAction( 'my_hook', [], new ActionScheduler_SimpleSchedule( $scheduled_date ) );
+		$store  = new DB_Store();
+
+		$action_id   = $store->save_action( $action, null, $last_attempt_date );
+		$action_date = $store->get_date( $action_id );
+
+		$this->assertEquals( $last_attempt_date->format( 'U' ), $action_date->format( 'U' ) );
+
+		$action_id   = $store->save_action( $action, $scheduled_date, $last_attempt_date );
+		$action_date = $store->get_date( $action_id );
+
+		$this->assertEquals( $last_attempt_date->format( 'U' ), $action_date->format( 'U' ) );
+	}
+
 	public function test_retrieve_action() {
 		$time      = as_get_datetime_object();
 		$schedule  = new ActionScheduler_SimpleSchedule( $time );


### PR DESCRIPTION
Build on the changes being added in Action Scheduler core with https://github.com/Prospress/action-scheduler/pull/144 to save an action's attempted date when it is migrated.

Fixes #10.

