### PR TITLE
Add DB_Store_Migrator to make sure last payment date is set when migrating failed/completed actions

### DIFF
--- a/src/DB_Store_Migrator.php
+++ b/src/DB_Store_Migrator.php
@@ -3,11 +3,6 @@
 namespace Action_Scheduler\Custom_Tables;
 
 use ActionScheduler_Action;
-use ActionScheduler_ActionClaim;
-use ActionScheduler_FinishedAction;
-use ActionScheduler_NullAction;
-use ActionScheduler_NullSchedule;
-use ActionScheduler_Store;
 
 class DB_Store_Migrator extends DB_Store {
 
@@ -19,13 +14,15 @@ class DB_Store_Migrator extends DB_Store {
 	 * that when first saving the action.
 	 *
 	 * @param ActionScheduler_Action $action
-	 * @param DateTime $scheduled_date Optional date of the first instance to store.
-	 * @param DateTime $last_attempt_date Optional date the action was last attempted.
+	 * @param \DateTime $scheduled_date Optional date of the first instance to store.
+	 * @param \DateTime $last_attempt_date Optional date the action was last attempted.
+	 *
 	 * @return string The action ID
+	 * @throws \RuntimeException When the action is not saved.
 	 */
 	public function save_action( ActionScheduler_Action $action, \DateTime $scheduled_date = null, \DateTime $last_attempt_date = null ){
 		try {
-			/** @var wpdb $wpdb */
+			/** @var \wpdb $wpdb */
 			global $wpdb;
 
 			$action_id = parent::save_action( $action, $scheduled_date );

--- a/src/DB_Store_Migrator.php
+++ b/src/DB_Store_Migrator.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Action_Scheduler\Custom_Tables;
+
+use ActionScheduler_Action;
+use ActionScheduler_ActionClaim;
+use ActionScheduler_FinishedAction;
+use ActionScheduler_NullAction;
+use ActionScheduler_NullSchedule;
+use ActionScheduler_Store;
+
+class DB_Store_Migrator extends DB_Store {
+
+	/**
+	 * Save an action with optional last attempt date.
+	 *
+	 * Normally, saving an action sets its attempted date to 0000-00-00 00:00:00 because when an action is first saved,
+	 * it can't have been attempted yet, but migrated completed actions will have an attempted date, so we need to save
+	 * that when first saving the action.
+	 *
+	 * @param ActionScheduler_Action $action
+	 * @param DateTime $scheduled_date Optional date of the first instance to store.
+	 * @param DateTime $last_attempt_date Optional date the action was last attempted.
+	 * @return string The action ID
+	 */
+	public function save_action( ActionScheduler_Action $action, \DateTime $scheduled_date = null, \DateTime $last_attempt_date = null ){
+		try {
+			/** @var wpdb $wpdb */
+			global $wpdb;
+
+			$action_id = parent::save_action( $action, $scheduled_date );
+
+			if ( null !== $last_attempt_date ) {
+				$data = [
+					'last_attempt_gmt'   => $this->get_timestamp( $action, $last_attempt_date ),
+					'last_attempt_local' => $this->get_local_timestamp( $action, $last_attempt_date ),
+				];
+
+				$wpdb->update( $wpdb->actionscheduler_actions, $data, array( 'action_id' => $action_id ), array( '%s', '%s' ), array( '%d' ) );
+			}
+
+			return $action_id;
+		} catch ( \Exception $e ) {
+			throw new \RuntimeException( sprintf( __( 'Error saving action: %s', 'action-scheduler' ), $e->getMessage() ), 0 );
+		}
+	}
+}

--- a/src/Migration/Action_Migrator.php
+++ b/src/Migration/Action_Migrator.php
@@ -37,7 +37,11 @@ class Action_Migrator {
 		}
 
 		try {
-			$destination_action_id = $this->destination->save_action( $action );
+
+			// Make sure the last attempt date is set correctly for completed and failed actions
+			$last_attempt_date = ( $status !== \ActionScheduler_Store::STATUS_PENDING ) ? $this->source->get_date( $source_action_id ) : null;
+
+			$destination_action_id = $this->destination->save_action( $action, null, $last_attempt_date );
 		} catch ( \Exception $e ) {
 			do_action( 'action_scheduler/custom_tables/migrate_action_failed', $source_action_id, $this->source, $this->destination );
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -94,7 +94,7 @@ class Plugin {
 		$config = new Migration\Migration_Config();
 		$config->set_source_store( new \ActionScheduler_wpPostStore() );
 		$config->set_source_logger( new \ActionScheduler_wpCommentLogger() );
-		$config->set_destination_store( new DB_Store() );
+		$config->set_destination_store( new DB_Store_Migrator() );
 		$config->set_destination_logger( new DB_Logger() );
 
 		return apply_filters( 'action_scheduler/custom_tables/migration_config', $config );

--- a/tests/phpunit/jobstore/DB_Store_Migrator_Test.php
+++ b/tests/phpunit/jobstore/DB_Store_Migrator_Test.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Action_Scheduler\Custom_Tables;
+use ActionScheduler_Action;
+use ActionScheduler_IntervalSchedule;
+use ActionScheduler_SimpleSchedule;
+use ActionScheduler_Store;
+
+/**
+ * Class DB_Store_Test
+ *
+ * @group stores
+ */
+class DB_Store_Test extends UnitTestCase {
+
+	public function test_create_action_with_last_attempt_date() {
+		$scheduled_date    = as_get_datetime_object( strtotime( '-24 hours' ) );
+		$last_attempt_date = as_get_datetime_object( strtotime( '-23 hours' ) );
+
+		$action = new ActionScheduler_FinishedAction( 'my_hook', [], new ActionScheduler_SimpleSchedule( $scheduled_date ) );
+		$store  = new DB_Store_Migrator();
+
+		$action_id   = $store->save_action( $action, null, $last_attempt_date );
+		$action_date = $store->get_date( $action_id );
+
+		$this->assertEquals( $last_attempt_date->format( 'U' ), $action_date->format( 'U' ) );
+
+		$action_id   = $store->save_action( $action, $scheduled_date, $last_attempt_date );
+		$action_date = $store->get_date( $action_id );
+
+		$this->assertEquals( $last_attempt_date->format( 'U' ), $action_date->format( 'U' ) );
+	}
+}
+ 

--- a/tests/phpunit/jobstore/DB_Store_Migrator_Test.php
+++ b/tests/phpunit/jobstore/DB_Store_Migrator_Test.php
@@ -1,17 +1,16 @@
 <?php
 
 namespace Action_Scheduler\Custom_Tables;
-use ActionScheduler_Action;
-use ActionScheduler_IntervalSchedule;
+
+use ActionScheduler_FinishedAction;
 use ActionScheduler_SimpleSchedule;
-use ActionScheduler_Store;
 
 /**
- * Class DB_Store_Test
+ * Class DB_Store_Migrator_Test
  *
  * @group stores
  */
-class DB_Store_Test extends UnitTestCase {
+class DB_Store_Migrator_Test extends UnitTestCase {
 
 	public function test_create_action_with_last_attempt_date() {
 		$scheduled_date    = as_get_datetime_object( strtotime( '-24 hours' ) );
@@ -31,4 +30,3 @@ class DB_Store_Test extends UnitTestCase {
 		$this->assertEquals( $last_attempt_date->format( 'U' ), $action_date->format( 'U' ) );
 	}
 }
- 


### PR DESCRIPTION
Fixes #10.