### PR TITLE
Increase batch size and frequency of migration via scheduler

### DIFF
--- a/src/Migration/Migration_Scheduler.php
+++ b/src/Migration/Migration_Scheduler.php
@@ -82,17 +82,17 @@ class Migration_Scheduler {
 	}
 
 	/**
-	 * @return int Seconds between migration runs. Defaults to five minutes.
+	 * @return int Seconds between migration runs. Defaults to two minutes.
 	 */
 	private function get_schedule_interval() {
-		return (int) apply_filters( 'action_scheduler/custom_tables/migration_interval', 5 * MINUTE_IN_SECONDS );
+		return (int) apply_filters( 'action_scheduler/custom_tables/migration_interval', 2 * MINUTE_IN_SECONDS );
 	}
 
 	/**
-	 * @return int Number of actions to migrate in each batch. Defaults to 100.
+	 * @return int Number of actions to migrate in each batch. Defaults to 1000.
 	 */
 	private function get_batch_size() {
-		return (int) apply_filters( 'action_scheduler/custom_tables/migration_batch_size', 100 );
+		return (int) apply_filters( 'action_scheduler/custom_tables/migration_batch_size', 1000 );
 	}
 
 	/**


### PR DESCRIPTION
To run the scheduled migration event more frequently and migrate more actions in each batch.

I'm not sure why the schedule was originally set to be 5 minutes apart, but it seems like way too much time between processing. I'm guessing it was done to avoid duplicate queues doing a migration at the same time, and/or to make sure it ran after the built-in timeout mechanism.

Now that https://github.com/Prospress/action-scheduler/issues/108 is implemented, I'm really not sure we need to give 5 minutes anymore.

Regarding batch size, on a (real) large site's database, it was taking less than 30 seconds to migrate a set of 1,000 actions (with 10,000 actions already in the new table and a post table with near 1,000,000 rows and post meta table near 50,000,000 rows). So it seems like 1,000 inserts in one request should be manageable. Even on lower powered servers. I think the previous thresholds were set simply to be conservative (which is reasonable given we have the Hybrid data store).

### Defaulting to a Conservative Approach

I am still in favour of taking a very conservative approach to the amount of data, and frequency of which we upgrade to avoid any potential issues across sites. If there's even remotely potential issues with these changes, then it should not be merged. Especially as we can just release a plugin using the available filters for larger sites where we might want to migrate things faster.