### PR TITLE
Order claims by ID

### DIFF
--- a/src/DB_Store.php
+++ b/src/DB_Store.php
@@ -459,7 +459,7 @@ class DB_Store extends ActionScheduler_Store {
 			$params[] = $group_id;
 		}
 
-		$order    = "ORDER BY attempts ASC, scheduled_date_gmt ASC LIMIT %d";
+		$order    = "ORDER BY attempts ASC, scheduled_date_gmt ASC, action_id ASC LIMIT %d";
 		$params[] = $limit;
 
 		$sql = $wpdb->prepare( "{$update} {$where} {$order}", $params );


### PR DESCRIPTION
So that if multiple actions are scheduled for the same time, they will be run in the order in which they were created/scheduled.

Fixes #21. Counterpart to Prospress/action-scheduler#139