### PR TITLE
Remove duplicate code in DB_Logger

### DIFF
--- a/src/DB_Logger.php
+++ b/src/DB_Logger.php
@@ -89,49 +89,9 @@ class DB_Logger extends \ActionScheduler_Logger {
 		$table_maker = new DB_Logger_Table_Maker();
 		$table_maker->register_tables();
 
-		add_action( 'action_scheduler_stored_action', [ $this, 'log_stored_action' ], 10, 1 );
-		add_action( 'action_scheduler_canceled_action', [ $this, 'log_canceled_action' ], 10, 1 );
-		add_action( 'action_scheduler_before_execute', [ $this, 'log_started_action' ], 10, 1 );
-		add_action( 'action_scheduler_after_execute', [ $this, 'log_completed_action' ], 10, 1 );
-		add_action( 'action_scheduler_failed_execution', [ $this, 'log_failed_action' ], 10, 2 );
-		add_action( 'action_scheduler_failed_action', [ $this, 'log_timed_out_action' ], 10, 2 );
-		add_action( 'action_scheduler_unexpected_shutdown', [ $this, 'log_unexpected_shutdown' ], 10, 2 );
-		add_action( 'action_scheduler_reset_action', [ $this, 'log_reset_action' ], 10, 1 );
+		parent::init();
+
 		add_action( 'action_scheduler_deleted_action', [ $this, 'clear_deleted_action_logs' ], 10, 1 );
-	}
-
-	public function log_stored_action( $action_id ) {
-		$this->log( $action_id, __( 'action created', 'action-scheduler' ) );
-	}
-
-	public function log_canceled_action( $action_id ) {
-		$this->log( $action_id, __( 'action canceled', 'action-scheduler' ) );
-	}
-
-	public function log_started_action( $action_id ) {
-		$this->log( $action_id, __( 'action started', 'action-scheduler' ) );
-	}
-
-	public function log_completed_action( $action_id ) {
-		$this->log( $action_id, __( 'action complete', 'action-scheduler' ) );
-	}
-
-	public function log_failed_action( $action_id, \Exception $exception ) {
-		$this->log( $action_id, sprintf( __( 'action failed: %s', 'action-scheduler' ), $exception->getMessage() ) );
-	}
-
-	public function log_timed_out_action( $action_id, $timeout ) {
-		$this->log( $action_id, sprintf( __( 'action timed out after %s seconds', 'action-scheduler' ), $timeout ) );
-	}
-
-	public function log_unexpected_shutdown( $action_id, $error ) {
-		if ( ! empty( $error ) ) {
-			$this->log( $action_id, sprintf( __( 'unexpected shutdown: PHP Fatal error %s in %s on line %s', 'action-scheduler' ), $error[ 'message' ], $error[ 'file' ], $error[ 'line' ] ) );
-		}
-	}
-
-	public function log_reset_action( $action_id ) {
-		$this->log( $action_id, __( 'action reset', 'action_scheduler' ) );
 	}
 
 	public function clear_deleted_action_logs( $action_id ) {


### PR DESCRIPTION
With Prospress/action-scheduler@bca46a8, we no longer need to duplicate so much code previously included from ActionScheduler_wpCommentLogger

Fixes #40