### PR TITLE
Check Action Scheduler Dependencies - Require v2.1.0

### DIFF
--- a/action-scheduler-custom-tables.php
+++ b/action-scheduler-custom-tables.php
@@ -12,4 +12,5 @@ namespace Action_Scheduler\Custom_Tables;
 
 require_once( __DIR__ . '/vendor/autoload.php' );
 
-add_action( 'plugins_loaded', [ Plugin::class, 'init' ], 0, 0 );
+// We need to hook in at the obscure 0.5 priority here, because ActionScheduler_Versions::initialize_latest_version() is attached at priority 1, while action_scheduler_register_{version_number_string}() callbacks at attached at priority 0
+add_action( 'plugins_loaded', [ Plugin::class, 'init' ], 0.5, 0 );

--- a/src/Dependencies.php
+++ b/src/Dependencies.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Action_Scheduler\Custom_Tables;
+
+/**
+ * Class Dependencies
+ *
+ * APIs for working with Action Scheduler dependencies, including public methods to check
+ * dependecies are met, and notify admins if they are not met.
+ */
+class Dependencies {
+
+	/**
+	 * @var string
+	 */
+	private $min_version = '2.1.0';
+
+	/**
+	 * @var string
+	 */
+	private $max_version = '3.0.0';
+
+	/**
+	 * Check Action Scheduler class is available and at required versions.
+	 *
+	 * @return bool
+	 */
+	public function dependencies_met() {
+		return $this->is_action_scheduler_available() && $this->is_action_scheduler_new_enough() && $this->is_action_scheduler_old_enough();
+	}
+
+	/**
+	 * Attach an admin notice in the WordPress admin about the missing dependeices (if any)
+	 */
+	public function add_notice() {
+		add_filter( 'admin_notices', [ $this, 'admin_notices' ], 10, 1 );
+	}
+
+	/**
+	 * Display an inactive notice when Action Scheduler is inactive or an invalid version is running.
+	 */
+	public function admin_notices() {
+		if ( ! $this->dependencies_met() && current_user_can( 'activate_plugins' ) ) : ?>
+<div id="message" class="error">
+	<p>
+		<?php
+		// translators: 1$-2$: opening and closing <strong> tags
+		printf( esc_html__( '%1$sThe Action Scheduler Custom Tables plugin is not running.%2$s', 'action-scheduler' ), '<strong>', '</strong>' );
+
+		$plugins_url = admin_url( 'plugins.php' );
+
+		if ( ! $this->is_action_scheduler_available() ) {
+			// translators: 1$-2$: link tags to the Action Scheduler GitHub page, 3$-4$: link tags for Plugins administration screen
+			printf( esc_html__( 'The %1$sAction Scheduler library%2$s must be active for this plugin to work. No instance of Action Scheduler was detected. Please %3$sinstall & activate Action Scheduler as a plugin &raquo;%4$s', 'action-scheduler' ), '<a href="https://github.com/prospress/action-scheduler">', '</a>', '<a href="' .  esc_url( $plugins_url ) . '">', '</a>' );
+		} elseif ( ! $this->is_action_scheduler_new_enough() ) {
+			// translators: 1$-2$: link tags to the Action Scheduler GitHub page, 3$-4$: version number, e.g. 2.1.0 5$-6$: link tags for Plugins administration screen
+			printf( esc_html__( 'The %1$sAction Scheduler library%2$s version %3$s or newer must be active for this plugin to work. Action Scheduler version %4$s was detected. Please %5$supdate Action Scheduler as a plugin &raquo;%6$s', 'action-scheduler' ), '<a href="https://github.com/prospress/action-scheduler">', '</a>', $this->min_version, $this->get_action_scheduler_version(), '<a href="' .  esc_url( $plugins_url ) . '">', '</a>' );
+		} elseif ( ! $this->is_action_scheduler_old_enough() ) {
+			// translators: 1$-2$: link tags to the Action Scheduler GitHub page, 3$-4$: version number, e.g. 2.1.0 5$-6$: link tags for Plugins administration screen
+			printf( esc_html__( 'This plugin is only required with %1$sAction Scheduler%2$s version %3$s or older. Action Scheduler version %4$s was detected. Please disable and delete the Action Scheduler Custom Tables plugin on the %5$sPlugins Administration screen &raquo;%6$s', 'action-scheduler' ), '<a href="https://github.com/prospress/action-scheduler">', '</a>', $this->max_version, $this->get_action_scheduler_version(), '<a href="' .  esc_url( $plugins_url ) . '">', '</a>' );
+		}
+		?>
+	</p>
+</div>
+	<?php endif;
+	}
+
+	/**
+	 * Check Action Scheduler class is available and at required versions.
+	 *
+	 * @return bool
+	 */
+	private function is_action_scheduler_available() {
+		return class_exists( 'ActionScheduler_Versions' );
+	}
+
+	/**
+	 * Action Scheduler v2.1.0 is the first version to provide all required APIs.
+	 *
+	 * @return bool
+	 */
+	private function is_action_scheduler_new_enough() {
+		return version_compare( $this->get_action_scheduler_version(), $this->min_version, '>=' );
+	}
+
+	/**
+	 * Action Scheduler v3.0.0 will include custom tables in core making this plugin unnecessary.
+	 *
+	 * @return bool
+	 */
+	private function is_action_scheduler_old_enough() {
+		return version_compare( $this->get_action_scheduler_version(), $this->max_version, '<' );
+	}
+
+	/**
+	 * Check Action Scheduler class is available and at required versions.
+	 *
+	 * @return string
+	 */
+	private function get_action_scheduler_version() {
+		return $this->is_action_scheduler_available() ? \ActionScheduler_Versions::instance()->latest_version() : '0.0.0';
+	}
+}

--- a/src/Migration/Migration_Scheduler.php
+++ b/src/Migration/Migration_Scheduler.php
@@ -56,7 +56,7 @@ class Migration_Scheduler {
 	 * @return bool Whether there is a pending action in the store to handle the migration
 	 */
 	public function is_migration_scheduled() {
-		$next = wc_next_scheduled_action( self::HOOK );
+		$next = as_next_scheduled_action( self::HOOK );
 
 		return ! empty( $next );
 	}
@@ -71,14 +71,14 @@ class Migration_Scheduler {
 			$when = time();
 		}
 
-		return wc_schedule_single_action( $when, self::HOOK, [], self::GROUP );
+		return as_schedule_single_action( $when, self::HOOK, [], self::GROUP );
 	}
 
 	/**
 	 * Removes the scheduled migration action
 	 */
 	public function unschedule_migration() {
-		wc_unschedule_action( self::HOOK, null, self::GROUP );
+		as_unschedule_action( self::HOOK, null, self::GROUP );
 	}
 
 	/**

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -20,6 +20,9 @@ use Action_Scheduler\Custom_Tables\Migration\Migration_Scheduler;
 class Plugin {
 	private static $instance;
 
+	/** @var Dependencies */
+	private static $dependency_handler;
+
 	/** @var Migration_Scheduler */
 	private $migration_scheduler;
 
@@ -28,8 +31,9 @@ class Plugin {
 	 *
 	 * @param Migration_Scheduler $migration_scheduler
 	 */
-	public function __construct( Migration_Scheduler $migration_scheduler ) {
+	public function __construct( Migration_Scheduler $migration_scheduler, Dependencies $dependency_handler ) {
 		$this->migration_scheduler = $migration_scheduler;
+		self::$dependency_handler  = $dependency_handler;
 	}
 
 	/**
@@ -136,12 +140,19 @@ class Plugin {
 	}
 
 	public static function init() {
-		self::instance()->hook();
+
+		self::instance();
+
+		if ( ! self::$dependency_handler->dependencies_met() ) {
+			self::instance()->hook();
+		} else {
+			self::$dependency_handler->add_notice();
+		}
 	}
 
 	public static function instance() {
 		if ( ! isset( self::$instance ) ) {
-			self::$instance = new static( new Migration_Scheduler() );
+			self::$instance = new static( new Migration_Scheduler(), new Dependencies() );
 		}
 
 		return self::$instance;

--- a/tests/phpunit/logging/DB_Logger_Test.php
+++ b/tests/phpunit/logging/DB_Logger_Test.php
@@ -18,7 +18,7 @@ class DB_Logger_Test extends UnitTestCase {
 	}
 
 	public function test_add_log_entry() {
-		$action_id = wc_schedule_single_action( time(), __METHOD__ );
+		$action_id = as_schedule_single_action( time(), __METHOD__ );
 		$logger = ActionScheduler::logger();
 		$message = 'Logging that something happened';
 		$log_id = $logger->log( $action_id, $message );
@@ -36,7 +36,7 @@ class DB_Logger_Test extends UnitTestCase {
 	}
 
 	public function test_storage_logs() {
-		$action_id = wc_schedule_single_action( time(), __METHOD__ );
+		$action_id = as_schedule_single_action( time(), __METHOD__ );
 		$logger = ActionScheduler::logger();
 		$logs = $logger->get_logs( $action_id );
 		$expected = new ActionScheduler_LogEntry( $action_id, 'action created' );
@@ -46,7 +46,7 @@ class DB_Logger_Test extends UnitTestCase {
 	}
 
 	public function test_execution_logs() {
-		$action_id = wc_schedule_single_action( time(), __METHOD__ );
+		$action_id = as_schedule_single_action( time(), __METHOD__ );
 		$logger = ActionScheduler::logger();
 		$started = new ActionScheduler_LogEntry( $action_id, 'action started' );
 		$finished = new ActionScheduler_LogEntry( $action_id, 'action complete' );
@@ -70,7 +70,7 @@ class DB_Logger_Test extends UnitTestCase {
 	public function test_failed_execution_logs() {
 		$hook = __METHOD__;
 		add_action( $hook, array( $this, '_a_hook_callback_that_throws_an_exception' ) );
-		$action_id = wc_schedule_single_action( time(), $hook );
+		$action_id = as_schedule_single_action( time(), $hook );
 		$logger = ActionScheduler::logger();
 		$started = new ActionScheduler_LogEntry( $action_id, 'action started' );
 		$finished = new ActionScheduler_LogEntry( $action_id, 'action complete' );
@@ -94,7 +94,7 @@ class DB_Logger_Test extends UnitTestCase {
 	}
 
 	public function test_fatal_error_log() {
-		$action_id = wc_schedule_single_action( time(), __METHOD__ );
+		$action_id = as_schedule_single_action( time(), __METHOD__ );
 		$logger = ActionScheduler::logger();
 		do_action( 'action_scheduler_unexpected_shutdown', $action_id, array(
 			'type' => E_ERROR,
@@ -114,8 +114,8 @@ class DB_Logger_Test extends UnitTestCase {
 	}
 
 	public function test_canceled_action_log() {
-		$action_id = wc_schedule_single_action( time(), __METHOD__ );
-		wc_unschedule_action( __METHOD__ );
+		$action_id = as_schedule_single_action( time(), __METHOD__ );
+		as_unschedule_action( __METHOD__ );
 		$logger = ActionScheduler::logger();
 		$logs = $logger->get_logs( $action_id );
 		$expected = new ActionScheduler_LogEntry( $action_id, 'action canceled' );


### PR DESCRIPTION
This PR introduces a new `Dependencies` class which is used to check Action Scheduler:

1. is available; and
1. is at the required minimum version, which is now 2.1.0, because we will need Prospress/action-scheduler@bca46a8 once #41 is merged; and
1. is not above 3.0.0, because in that version, we will merge custom table stores into AS core.

Screenshots of the admin notice for each case:

1. No AS: https://cl.ly/3N0u3h323g3F
1. AS < 2.1.0:  https://cl.ly/292E100V0t3h
1. AS >= 3.0.0: https://cl.ly/2s0J3c0q2e1A

The abstraction could be improved here to make `Dependencies` less _dependent_ on Action Scheduler and reusable for other dependences, like PHP version; however, this code is only going to be used as a plugin for a few months until custom tables are merged into AS 3.0, so I didn't want to over-engineer it.

---

To get the unit tests passing, I also added SHA: 9ed7df43464853b06 to this PR to [fix `Unexpected deprecated notice` errors with Travis](https://travis-ci.org/Prospress/action-scheduler-custom-tables/jobs/415776406#L523).