### PR TITLE
Fix use of deprecated get_local_timezone()

### DIFF
--- a/src/DB_Logger.php
+++ b/src/DB_Logger.php
@@ -26,7 +26,7 @@ class DB_Logger extends \ActionScheduler_Logger {
 		}
 
 		$date_gmt = $date->format( 'Y-m-d H:i:s' );
-		$date->setTimezone( ActionScheduler_TimezoneHelper::get_local_timezone() );
+		ActionScheduler_TimezoneHelper::set_local_timezone( $date );
 		$date_local = $date->format( 'Y-m-d H:i:s' );
 
 		/** @var \wpdb $wpdb */

--- a/src/DB_Store.php
+++ b/src/DB_Store.php
@@ -9,6 +9,7 @@ use ActionScheduler_FinishedAction;
 use ActionScheduler_NullAction;
 use ActionScheduler_NullSchedule;
 use ActionScheduler_Store;
+use ActionScheduler_TimezoneHelper;
 
 class DB_Store extends ActionScheduler_Store {
 
@@ -367,8 +368,8 @@ class DB_Store extends ActionScheduler_Store {
 	 */
 	public function get_date( $action_id ) {
 		$date = $this->get_date_gmt( $action_id );
-
-		return $date->setTimezone( $this->get_local_timezone() );
+		ActionScheduler_TimezoneHelper::set_local_timezone( $date );
+		return $date;
 	}
 
 	/**


### PR DESCRIPTION
Deprecated in v2.1.0 (which ASCT now requires).