### PR TITLE
Only hook migration when AS is available

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -80,7 +80,7 @@ class Plugin {
 	 * @return void
 	 */
 	public function schedule_migration() {
-		if ( $this->migration_scheduler->is_migration_complete() || $this->migration_scheduler->is_migration_scheduled() ) {
+		if ( ! self::$dependency_handler->dependencies_met() || $this->migration_scheduler->is_migration_complete() || $this->migration_scheduler->is_migration_scheduled() ) {
 			return;
 		}
 


### PR DESCRIPTION
There's no guarantee AS will be available/loaded on the `'shutdown'` hook, because something could be terminating the request prior to `'plugins_loaded'` priority `1` (like #46).

Fixes #30