### PR TITLE
Fix dependency check

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -143,7 +143,7 @@ class Plugin {
 
 		self::instance();
 
-		if ( ! self::$dependency_handler->dependencies_met() ) {
+		if ( self::$dependency_handler->dependencies_met() ) {
 			self::instance()->hook();
 		} else {
 			self::$dependency_handler->add_notice();


### PR DESCRIPTION
PR #42 introduced a dependency check to make sure AS 2.1.0 or newer was active before loading. The logic on the check was wrong - we need dependencies to be met, not for them to be unmet.

Fixes #46