### PR TITLE
Fix dates of migrated log entries:

### DIFF
--- a/src/DB_Logger.php
+++ b/src/DB_Logger.php
@@ -64,7 +64,9 @@ class DB_Logger extends \ActionScheduler_Logger {
 			return new ActionScheduler_NullLogEntry();
 		}
 
-		return new ActionScheduler_LogEntry( $record->action_id, $record->message );
+		$date = as_get_datetime_object( $record->log_date_gmt );
+
+		return new ActionScheduler_LogEntry( $record->action_id, $record->message, $date );
 	}
 
 	/**

--- a/src/Migration/Action_Migrator.php
+++ b/src/Migration/Action_Migrator.php
@@ -9,9 +9,10 @@ class Action_Migrator {
 	private $destination;
 	private $log_migrator;
 
-	public function __construct( \ActionScheduler_Store $source_store, \ActionScheduler_Store $destination_store ) {
-		$this->source      = $source_store;
-		$this->destination = $destination_store;
+	public function __construct( \ActionScheduler_Store $source_store, \ActionScheduler_Store $destination_store, Log_Migrator $log_migrator ) {
+		$this->source       = $source_store;
+		$this->destination  = $destination_store;
+		$this->log_migrator = $log_migrator;
 	}
 
 	public function migrate( $source_action_id ) {
@@ -68,9 +69,5 @@ class Action_Migrator {
 
 			return $destination_action_id;
 		}
-	}
-
-	public function set_log_migrator( Log_Migrator $log_migrator ) {
-		$this->log_migrator = $log_migrator;
 	}
 }

--- a/src/Migration/Action_Migrator.php
+++ b/src/Migration/Action_Migrator.php
@@ -7,6 +7,7 @@ namespace Action_Scheduler\Custom_Tables\Migration;
 class Action_Migrator {
 	private $source;
 	private $destination;
+	private $log_migrator;
 
 	public function __construct( \ActionScheduler_Store $source_store, \ActionScheduler_Store $destination_store ) {
 		$this->source      = $source_store;
@@ -50,9 +51,11 @@ class Action_Migrator {
 
 
 		try {
-			if ( $status == \ActionScheduler_Store::STATUS_FAILED ) {
+			if ( $status === \ActionScheduler_Store::STATUS_FAILED ) {
 				$this->destination->mark_failure( $destination_action_id );
 			}
+
+			$this->log_migrator->migrate( $source_action_id, $destination_action_id );
 			$this->source->delete_action( $source_action_id );
 
 			do_action( 'action_scheduler/custom_tables/migrated_action', $source_action_id, $destination_action_id, $this->source, $this->destination );
@@ -65,5 +68,9 @@ class Action_Migrator {
 
 			return $destination_action_id;
 		}
+	}
+
+	public function set_log_migrator( Log_Migrator $log_migrator ) {
+		$this->log_migrator = $log_migrator;
 	}
 }

--- a/src/Migration/Log_Migrator.php
+++ b/src/Migration/Log_Migrator.php
@@ -19,7 +19,7 @@ class Log_Migrator {
 		$logs = $this->source->get_logs( $source_action_id );
 		foreach ( $logs as $log ) {
 			if ( $log->get_action_id() == $source_action_id ) {
-				$this->destination->log( $destination_action_id, $log->get_message() );
+				$this->destination->log( $destination_action_id, $log->get_message(), $log->get_date() );
 			}
 		}
 	}

--- a/src/Migration/Migration_Runner.php
+++ b/src/Migration/Migration_Runner.php
@@ -27,6 +27,8 @@ class Migration_Runner {
 			$this->action_migrator = new Action_Migrator( $this->source_store, $this->destination_store );
 			$this->log_migrator    = new Log_Migrator( $this->source_logger, $this->destination_logger );
 		}
+
+		$this->action_migrator->set_log_migrator( $this->log_migrator );
 	}
 
 	public function run( $batch_size = 10 ) {
@@ -40,10 +42,11 @@ class Migration_Runner {
 	public function migrate_actions( array $action_ids ) {
 		do_action( 'action_scheduler/custom_tables/migration_batch_starting', $action_ids );
 
+		remove_all_actions( 'action_scheduler_stored_action' );
+
 		foreach ( $action_ids as $source_action_id ) {
 			$destination_action_id = $this->action_migrator->migrate( $source_action_id );
 			if ( $destination_action_id ) {
-				$this->log_migrator->migrate( $source_action_id, $destination_action_id );
 				$this->destination_logger->log( $destination_action_id, sprintf(
 					__( 'Migrated action with ID %d in %s to ID %d in %s', 'action-scheduler' ),
 					$source_action_id,

--- a/src/Migration/Migration_Runner.php
+++ b/src/Migration/Migration_Runner.php
@@ -40,8 +40,8 @@ class Migration_Runner {
 	public function migrate_actions( array $action_ids ) {
 		do_action( 'action_scheduler/custom_tables/migration_batch_starting', $action_ids );
 
-		remove_action( 'action_scheduler_stored_action', array( \ActionScheduler::logger(), 'log_stored_action', 10 ) );
-		remove_action( 'action_scheduler_stored_action', array( $this->destination_logger, 'log_stored_action', 10 ) );
+		remove_action( 'action_scheduler_stored_action', array( \ActionScheduler::logger(), 'log_stored_action' ), 10 );
+		remove_action( 'action_scheduler_stored_action', array( $this->destination_logger, 'log_stored_action' ), 10 );
 
 		foreach ( $action_ids as $source_action_id ) {
 			$destination_action_id = $this->action_migrator->migrate( $source_action_id );
@@ -55,6 +55,9 @@ class Migration_Runner {
 				) );
 			}
 		}
+
+		add_action( 'action_scheduler_stored_action', array( \ActionScheduler::logger(), 'log_stored_action' ), 10 , 1 );
+		add_action( 'action_scheduler_stored_action', array( $this->destination_logger, 'log_stored_action' ), 10, 1 );
 
 		do_action( 'action_scheduler/custom_tables/migration_batch_complete', $action_ids );
 	}

--- a/tests/phpunit/migration/Action_Migrator_Test.php
+++ b/tests/phpunit/migration/Action_Migrator_Test.php
@@ -3,6 +3,7 @@
 namespace Action_Scheduler\Custom_Tables;
 
 use Action_Scheduler\Custom_Tables\Migration\Action_Migrator;
+use Action_Scheduler\Custom_Tables\Migration\Log_Migrator;
 use ActionScheduler_Action;
 use ActionScheduler_SimpleSchedule;
 use ActionScheduler_wpPostStore;
@@ -20,7 +21,7 @@ class Action_Migrator_Test extends UnitTestCase {
 	public function test_migrate_from_wpPost_to_db() {
 		$source = new ActionScheduler_wpPostStore();
 		$destination = new DB_Store();
-		$migrator = new Action_Migrator( $source, $destination );
+		$migrator = new Action_Migrator( $source, $destination, $this->get_log_migrator() );
 
 		$time      = as_get_datetime_object();
 		$schedule  = new ActionScheduler_SimpleSchedule( $time );
@@ -46,7 +47,7 @@ class Action_Migrator_Test extends UnitTestCase {
 	public function test_does_not_migrate_missing_action_from_wpPost_to_db() {
 		$source = new ActionScheduler_wpPostStore();
 		$destination = new DB_Store();
-		$migrator = new Action_Migrator( $source, $destination );
+		$migrator = new Action_Migrator( $source, $destination, $this->get_log_migrator() );
 
 		$action_id = rand( 100, 100000 );
 
@@ -61,7 +62,7 @@ class Action_Migrator_Test extends UnitTestCase {
 	public function test_migrate_completed_action_from_wpPost_to_db() {
 		$source = new ActionScheduler_wpPostStore();
 		$destination = new DB_Store();
-		$migrator = new Action_Migrator( $source, $destination );
+		$migrator = new Action_Migrator( $source, $destination, $this->get_log_migrator() );
 
 		$time      = as_get_datetime_object();
 		$schedule  = new ActionScheduler_SimpleSchedule( $time );
@@ -88,7 +89,7 @@ class Action_Migrator_Test extends UnitTestCase {
 	public function test_migrate_failed_action_from_wpPost_to_db() {
 		$source = new ActionScheduler_wpPostStore();
 		$destination = new DB_Store();
-		$migrator = new Action_Migrator( $source, $destination );
+		$migrator = new Action_Migrator( $source, $destination, $this->get_log_migrator() );
 
 		$time      = as_get_datetime_object();
 		$schedule  = new ActionScheduler_SimpleSchedule( $time );
@@ -115,7 +116,7 @@ class Action_Migrator_Test extends UnitTestCase {
 	public function test_does_not_migrate_canceled_action_from_wpPost_to_db() {
 		$source = new ActionScheduler_wpPostStore();
 		$destination = new DB_Store();
-		$migrator = new Action_Migrator( $source, $destination );
+		$migrator = new Action_Migrator( $source, $destination, $this->get_log_migrator() );
 
 		$time      = as_get_datetime_object();
 		$schedule  = new ActionScheduler_SimpleSchedule( $time );
@@ -130,5 +131,9 @@ class Action_Migrator_Test extends UnitTestCase {
 		// ensure that the record in the old store does not exist
 		$old_action = $source->fetch_action( $action_id );
 		$this->assertInstanceOf( 'ActionScheduler_NullAction', $old_action );
+	}
+
+	private function get_log_migrator() {
+		return new Log_Migrator( \ActionScheduler::logger(), new DB_Logger() );
 	}
 }


### PR DESCRIPTION
Fixes #45 

- Move the log migration to occur before the action record is deleted
- Add the source log entry datetime to the destination log entry
- Include the log entry date when getting an existing log entry
- Unhook the default `action created` log entry which uses the current time

@thenbrent , @JPry do you think I should look at a way to re-hook the `action created` hooks after the batch is done?