### PR TITLE
add support for basic list table search

### DIFF
--- a/src/DB_Store.php
+++ b/src/DB_Store.php
@@ -252,6 +252,21 @@ class DB_Store extends ActionScheduler_Store {
 			$sql_params[] = $query[ 'claimed' ];
 		}
 
+		if ( ! empty( $query['search'] ) ) {
+			$sql .= " AND (a.hook LIKE %s OR a.args LIKE %s";
+			for( $i = 0; $i < 2; $i++ ) {
+				$sql_params[] = sprintf( '%%%s%%', $query['search'] );
+			}
+
+			$search_claim_id = (int) $query['search'];
+			if ( $search_claim_id ) {
+				$sql .= ' OR a.claim_id = %d';
+				$sql_params[] = $search_claim_id;
+			}
+
+			$sql .= ')';
+		}
+
 		if ( 'select' === $select_or_count ) {
 			switch ( $query['orderby'] ) {
 				case 'hook':


### PR DESCRIPTION
Fixes #18 

This PR adds the search in hook name, hook args or claim ID. The search query reflects that in the DB store the `claim_id` field is an integer. 

To test the `claim_id`, I did a manual DB update to give some scheduled actions a claim id of `12345` the searched for that value in the dashboard.