### PR TITLE
Init and hook plugin when dependencies are met

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -143,7 +143,7 @@ class Plugin {
 
 		self::instance();
 
-		if ( ! self::$dependency_handler->dependencies_met() ) {
+		if ( self::$dependency_handler->dependencies_met() ) {
 			self::instance()->hook();
 		} else {
 			self::$dependency_handler->add_notice();


### PR DESCRIPTION
Init and hook the plugin when dependencies are met. Without this patch, the plugin isn't initialised and so migration is never triggered. 
